### PR TITLE
Call font-lock-flush after toggling mode

### DIFF
--- a/fontify-face.el
+++ b/fontify-face.el
@@ -64,7 +64,8 @@ region if it represents a face, no face is returned."
    limit t))
 
 (defconst fontify-face-keywords
-  `((fontify-face-find-next-symbol 0 (funcall 'fontify-face-colorize-matched-face)))
+  '((fontify-face-find-next-symbol
+     0 (funcall 'fontify-face-colorize-matched-face)))
   "Keywords used for highlighting faces.
 
 Note: instead of using constants we use functions which are not

--- a/fontify-face.el
+++ b/fontify-face.el
@@ -1,4 +1,4 @@
-;;; fontify-face.el --- Fontify symbols representing faces with that face. -*- lexical-binding: t -*-
+;;; fontify-face.el --- Fontify symbols representing faces with that face  -*- lexical-binding:t -*-
 
 ;; Copyright (C) 2018 Matúš Goljer
 

--- a/fontify-face.el
+++ b/fontify-face.el
@@ -25,9 +25,12 @@
 
 ;;; Commentary:
 
-;; Fontify symbols representing faces with that face.
+;; This package defines the mode `fontify-face-mode', which
+;; fontifies symbols representing faces with the that face.
 
-;; See https://github.com/Fuco1/fontify-face
+;; During theme or package development it is useful to see how
+;; the faces look directly during development.  This saves time
+;; and provides thighter feedback loop.  Happy theming!
 
 ;;; Code:
 

--- a/fontify-face.el
+++ b/fontify-face.el
@@ -7,7 +7,7 @@
 ;; Version: 1.0.0
 ;; Created: 10th April 2018
 ;; URL: https://github.com/Fuco1/fontify-face
-;; Package-requires: ((emacs "24"))
+;; Package-requires: ((emacs "25"))
 ;; Keywords: faces
 
 ;; This program is free software; you can redistribute it and/or
@@ -74,7 +74,8 @@ display somewhat reliable during updates.")
   :lighter fontify-face-mode-lighter
   (if fontify-face-mode
       (font-lock-add-keywords nil fontify-face-keywords)
-    (font-lock-remove-keywords nil fontify-face-keywords)))
+    (font-lock-remove-keywords nil fontify-face-keywords))
+  (font-lock-flush))
 
 (provide 'fontify-face)
 ;;; fontify-face.el ends here

--- a/fontify-face.el
+++ b/fontify-face.el
@@ -7,7 +7,7 @@
 ;; Version: 1.0.0
 ;; Created: 10th April 2018
 ;; URL: https://github.com/Fuco1/fontify-face
-;; Package-requires: ((emacs "25"))
+;; Package-requires: ((emacs "25.1"))
 ;; Keywords: faces
 
 ;; This program is free software; you can redistribute it and/or


### PR DESCRIPTION
Minor-modes that add additional keywords generally have to do that,
for its addition (or their removal) to take effect in regions that
have already been fontified.

This function was added in Emacs 25.1, which was released in 2009.
Nearly a decade later, it should be okay to start depending on that.
Call font-lock-flush after toggling mode

Minor-modes that add additional keywords generally have to do that,
for its addition (or their removal) to take effect in regions that
have already been fontified.

This function was added in Emacs 25.1, which was released in 2009.
Nearly a decade later, it should be okay to start depending on that.

Because this package hasn't been touched in a few years and might
very well not be edited again any time soon, I kindly ask that you
consider creating Call font-lock-flush after toggling mode

Minor-modes that add additional keywords generally have to do that,
for its addition (or their removal) to take effect in regions that
have already been fontified.

This function was added in Emacs 25.1, which was released in 2009.
Nearly a decade later, it should be okay to start depending on that.
a new release after merging this.

While at it, I also snug some more commits with cosmetic tweaks.
If you disagree with those, please just drop them before merging.
(Or ask me to do it, in case you are not using Forge, which would
make that painless.)